### PR TITLE
Update GKContactDetailView.swift

### DIFF
--- a/Contacts/Classes/GKModules/Detail/GKContactDetailView.swift
+++ b/Contacts/Classes/GKModules/Detail/GKContactDetailView.swift
@@ -352,7 +352,7 @@ extension GKContactDetailView  {
                     cell.controller = self
                     cell.mobileTextField.isUserInteractionEnabled = (self.viewMode == .edit || self.viewMode == .add)
                     cell.mobileTextField.delegate = self
-                    cell.mobileTextField.keyboardType = .numbersAndPunctuation
+                    cell.mobileTextField.keyboardType = .phonePad
                     if let contact = self.contact {
                         cell.contact = contact
                     }


### PR DESCRIPTION
Use `UIKeyboardType`’s `.phonePad` instead of `.namePhonePad` for adding and editing phone numbers. Tested on simulators and iPhone Xs Max.